### PR TITLE
fix: clear unnecessary docker resources

### DIFF
--- a/faucet/deploy.sh
+++ b/faucet/deploy.sh
@@ -3,6 +3,7 @@
 # cd ~/faucet
 # curl -O https://raw.githubusercontent.com/UnUniFi/chain/main/faucet/deploy.sh
 docker-compose down
+docker system prune -a -f
 curl -O https://raw.githubusercontent.com/UnUniFi/chain/main/faucet/docker-compose.yml
 curl -O https://raw.githubusercontent.com/UnUniFi/chain/main/faucet/nginx.conf
 docker cp $(docker ps -qf "name=ununifid"):/usr/bin/ununifid ~/faucet/ununifid

--- a/launch/ununifi-6-test/start-ununifi-6-test.sh
+++ b/launch/ununifi-6-test/start-ununifi-6-test.sh
@@ -4,6 +4,7 @@ date
 
 cd ~/ununifi
 docker-compose down
+docker system prune -a -f
 
 docker pull ghcr.io/ununifi/ununifid:latest
 


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。

ノード上に古いdockerイメージ等が残ってストレージ容量を圧迫しないよう、デプロイスクリプトに古いイメージ等をクリアする実装を加えました。