### PR TITLE
feat: cd to publish docker image of private testnet with test tag

### DIFF
--- a/.github/workflows/docker-private-test.yml
+++ b/.github/workflows/docker-private-test.yml
@@ -1,0 +1,29 @@
+name: Publish Docker image for Private Testnet
+on:
+  push:
+    branches: 
+      - develop
+jobs:
+  push_to_registry:
+    name: Push Docker image for Private Testnet to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup variables
+        id: variables
+        run: echo "::set-output name=version::${GITHUB_REF##*/}"
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/ununifi/ununifid:test

--- a/launch/ununifi-7-private-test/start-ununifi-7-private-test.sh
+++ b/launch/ununifi-7-private-test/start-ununifi-7-private-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+date
+
+cd ~/ununifi
+docker-compose down
+docker system prune -a -f
+
+docker pull ghcr.io/ununifi/ununifid:test
+
+rm ~/.ununifi/config/genesis.json
+curl -L https://raw.githubusercontent.com/UnUniFi/chain/main/launch/ununifi-7-private-test/genesis.json -o ~/.ununifi/config/genesis.json
+
+docker run -it -v ~/.ununifi:/root/.ununifi ghcr.io/ununifi/ununifid ununifid unsafe-reset-all
+sudo chown -c -R $USER:docker ~/.ununifi
+
+cd ~/ununifi
+curl -O https://raw.githubusercontent.com/UnUniFi/chain/main/docker-compose.yml
+
+docker-compose up -d
+
+date


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。

developブランチにマージされたら、プライベートテストネット用のDockerイメージをタグ: testで公開するGitHub Actionsを作成しました。
次のプライベートテストネットのchain-id=ununifi-7-private-testのローンチ用のスクリプトにもタグの変更を反映しておきました。