### PR TITLE
fix: cd to disable docker image push on release published

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,6 @@
 name: Publish Docker image
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub


### PR DESCRIPTION
@mkXultra 
plz review 🙏 

Disable the CD because if the current CD runs at release time, a Docker image inconsistent with the current public testnet will be published.
And, instead, I will change the CD to be triggered manually.