### PR TITLE
fix: delete vestingcli line

### DIFF
--- a/cmd/ununifid/cmd/root.go
+++ b/cmd/ununifid/cmd/root.go
@@ -25,7 +25,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
-	vestingcli "github.com/cosmos/cosmos-sdk/x/auth/vesting/client/cli"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
@@ -173,7 +172,6 @@ func txCommand() *cobra.Command {
 		authcmd.GetEncodeCommand(),
 		authcmd.GetDecodeCommand(),
 		flags.LineBreak,
-		vestingcli.GetTxCmd(),
 	)
 
 	app.ModuleBasics.AddTxCommands(cmd)


### PR DESCRIPTION
This PR is for [issue#173](https://github.com/UnUniFi/chain/issues/173) that remove the additional tx command option of vesting.

The change is here:
Before
```
$ ununifid tx --help
Result related to this issue
  validate-signatures validate transactions signatures
  vesting             Vesting transaction subcommands
  vesting             Vesting transaction subcommands
  wasm                Wasm transaction subcommands
```
After
```
$ ununifid tx --help
Result related to this issue
  validate-signatures validate transactions signatures
  vesting             Vesting transaction subcommands
  wasm                Wasm transaction subcommands
```

I checked if this binary can start network and working and executing vesting command.