### PR TITLE
feat: change-metamask-address-rule

### DIFF
--- a/app/ante/sigverify.go
+++ b/app/ante/sigverify.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -303,7 +302,10 @@ func VerifyEthereumSignature(cdc codec.Codec, pubKey cryptotypes.PubKey, signerD
 		if err != nil {
 			return err
 		}
-		recoveredAddr := crypto.PubkeyToAddress(*recovered)
+
+		recoveredPubKey := secp256k1.PubKey{Key: crypto.CompressPubkey(recovered)}
+		recoveredAddress := sdk.AccAddress(recoveredPubKey.Address())
+		recoveredEthereumAddr := crypto.PubkeyToAddress(*recovered)
 
 		sigTx, ok := tx.(authsigning.SigVerifiableTx)
 		if !ok {
@@ -317,8 +319,8 @@ func VerifyEthereumSignature(cdc codec.Codec, pubKey cryptotypes.PubKey, signerD
 
 		address := signerAddrs[0]
 
-		if recoveredAddr.String() != common.BytesToAddress(address).String() {
-			return fmt.Errorf("mismatching recovered address and sender: %s != %s", recoveredAddr.String(), common.BytesToAddress(address).String())
+		if recoveredAddress.String() != address.String() {
+			return fmt.Errorf("mismatching recovered address and sender.\n  recovered: %s\n  sender: %s\n  recovered ethereum address: %s", recoveredAddress.String(), address.String(), recoveredEthereumAddr.String())
 		}
 		return nil
 	default:


### PR DESCRIPTION
I succeeded to send tx with:

- metamask address: `0x6264c07ea0A1E7258d9186b7f7203c4cf88913A1`
- recovered compressed pubkey: `0370265a37df3c886d3692af1b8210c2f8bd6fb4007acdb1c4c2012c663989fff4`
- ununifi address: `ununifi1amt7px7zs9u0000ptwe6tggxzv9lrnuxpqu2ke`

In this repo, the way of calculating address is normal way of cosmos sdk from pubkey.