### PR TITLE
Patch/derivatives taiki

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -226,6 +226,7 @@ var (
 		incentive.AppModuleBasic{},
 		nftmint.AppModuleBasic{},
 		nftmarket.AppModuleBasic{},
+		derivatives.AppModuleBasic{},
 		// wasm.AppModuleBasic{},
 	)
 
@@ -245,9 +246,10 @@ var (
 		ecosystemincentivetypes.ModuleName: nil,
 		ununifidisttypes.ModuleName:        {authtypes.Minter},
 		// wasm.ModuleName:             {authtypes.Burner},
-		nft.ModuleName:            nil,
-		nftminttypes.ModuleName:   nil,
-		nftmarkettypes.ModuleName: nil,
+		nft.ModuleName:              nil,
+		nftminttypes.ModuleName:     nil,
+		nftmarkettypes.ModuleName:   nil,
+		derivativestypes.ModuleName: {authtypes.Minter, authtypes.Burner},
 		// nftmarkettypes.NftTradingFee: nil,
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -113,6 +113,7 @@ import (
 	"github.com/UnUniFi/chain/x/cdp"
 	cdpkeeper "github.com/UnUniFi/chain/x/cdp/keeper"
 	cdptypes "github.com/UnUniFi/chain/x/cdp/types"
+	"github.com/UnUniFi/chain/x/derivatives"
 	derivativeskeeper "github.com/UnUniFi/chain/x/derivatives/keeper"
 	derivativestypes "github.com/UnUniFi/chain/x/derivatives/types"
 	ecosystemincentive "github.com/UnUniFi/chain/x/ecosystem-incentive"
@@ -671,6 +672,7 @@ func NewApp(
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
 
+	// tbbbt
 	app.mm = module.NewManager(
 		genutil.NewAppModule(
 			app.AccountKeeper,
@@ -701,6 +703,7 @@ func NewApp(
 		auction.NewAppModule(appCodec, app.auctionKeeper, app.AccountKeeper, app.BankKeeper),
 		cdp.NewAppModule(appCodec, app.cdpKeeper, app.AccountKeeper, app.BankKeeper, app.pricefeedKeeper),
 		ecosystemincentive.NewAppModule(appCodec, app.EcosystemincentiveKeeper, app.BankKeeper),
+		derivatives.NewAppModule(appCodec, app.DerivativesKeeper, app.AccountKeeper, app.BankKeeper),
 		incentive.NewAppModule(appCodec, app.incentiveKeeper, app.AccountKeeper, app.BankKeeper, app.cdpKeeper),
 		ununifidist.NewAppModule(appCodec, app.ununifidistKeeper, app.AccountKeeper, app.BankKeeper),
 		pricefeed.NewAppModule(appCodec, app.pricefeedKeeper, app.AccountKeeper),
@@ -741,7 +744,7 @@ func NewApp(
 		pricefeedtypes.ModuleName,
 		nftminttypes.ModuleName,
 		nftmarkettypes.ModuleName,
-
+		derivativestypes.ModuleName,
 		// ibchost.ModuleName,
 		// ibctransfertypes.ModuleName,
 		// wasm.ModuleName,
@@ -775,6 +778,7 @@ func NewApp(
 		nftminttypes.ModuleName,
 		nftmarkettypes.ModuleName,
 		ecosystemincentivetypes.ModuleName,
+		derivativestypes.ModuleName,
 		// ibchost.ModuleName,
 		// ibctransfertypes.ModuleName,
 		// wasm.ModuleName,
@@ -816,6 +820,7 @@ func NewApp(
 		nftminttypes.ModuleName,
 		nftmarkettypes.ModuleName,
 		ecosystemincentivetypes.ModuleName,
+		derivativestypes.ModuleName,
 		// ibchost.ModuleName,
 		// ibctransfertypes.ModuleName,
 		// wasm after ibc transfer
@@ -1103,5 +1108,6 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	// paramsKeeper.Subspace(wasm.ModuleName)
 	paramsKeeper.Subspace(nftminttypes.ModuleName)
 	paramsKeeper.Subspace(ecosystemincentivetypes.ModuleName)
+	paramsKeeper.Subspace(derivativestypes.ModuleName)
 	return paramsKeeper
 }

--- a/x/derivatives/keeper/msg_server.go
+++ b/x/derivatives/keeper/msg_server.go
@@ -3,8 +3,9 @@ package keeper
 import (
 	"context"
 
-	"github.com/UnUniFi/chain/x/derivatives/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/UnUniFi/chain/x/derivatives/types"
 )
 
 type msgServer struct {

--- a/x/derivatives/module.go
+++ b/x/derivatives/module.go
@@ -72,7 +72,9 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+		panic(err)
+	}
 }
 
 // GetTxCmd returns the root Tx command for the module. The subcommands of this root command are used by end-users to generate new transactions containing messages defined in the module

--- a/x/derivatives/module.go
+++ b/x/derivatives/module.go
@@ -127,7 +127,7 @@ func (am AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
 
 // RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	// types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 

--- a/x/derivatives/module.go
+++ b/x/derivatives/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	// this line is used by starport scaffolding # 1
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -11,14 +12,15 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	"github.com/UnUniFi/chain/x/derivatives/client/cli"
-	"github.com/UnUniFi/chain/x/derivatives/keeper"
-	"github.com/UnUniFi/chain/x/derivatives/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/UnUniFi/chain/x/derivatives/client/cli"
+	"github.com/UnUniFi/chain/x/derivatives/keeper"
+	"github.com/UnUniFi/chain/x/derivatives/types"
 )
 
 var (
@@ -123,7 +125,7 @@ func (am AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
 
 // RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	// types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 


### PR DESCRIPTION
Modified relating app.go.

Before, `derivatives` module wan't well initiated due to the lack of the config in app.go.
e.g. 
- `derivatives` queries and msgs didn't show up in cli.
- `derivatives` module genesis state didn't show up in genesis.json 
- `derivatives` module didn't actually work even if the network is running

I modified to solve those.
Plz review @KimuraYu45z cc: @inotite 

