### PR TITLE
[WIP] fix sub method error by setting initial mintfee coin

### DIFF
--- a/x/derivatives/keeper/lpt.go
+++ b/x/derivatives/keeper/lpt.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/UnUniFi/chain/x/derivatives/types"
@@ -133,9 +131,6 @@ func (k Keeper) MintLiquidityProviderToken(ctx sdk.Context, msg *types.MsgMintLi
 	if err != nil {
 		return err
 	}
-
-	fmt.Println("\nmintAmount\n", mintAmount)
-	fmt.Println("\nmintFee\n", mintFee)
 
 	err = k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.Coins{mintAmount})
 	if err != nil {

--- a/x/derivatives/keeper/lpt.go
+++ b/x/derivatives/keeper/lpt.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/UnUniFi/chain/x/derivatives/types"
@@ -47,7 +49,13 @@ func (k Keeper) GetLPTokenAmount(ctx sdk.Context, amount sdk.Coin) (sdk.Coin, sd
 	currentSupply := k.bankKeeper.GetSupply(ctx, types.LiquidityProviderTokenDenom)
 
 	if currentSupply.Amount.IsZero() {
-		return sdk.NewCoin(types.LiquidityProviderTokenDenom, sdk.NewInt(1)), sdk.Coin{}, nil
+		return sdk.NewCoin(
+				types.LiquidityProviderTokenDenom, sdk.NewInt(1)),
+			sdk.Coin{
+				Denom:  types.LiquidityProviderTokenDenom,
+				Amount: sdk.ZeroInt(),
+			},
+			nil
 	}
 
 	lptPrice := k.GetLPTokenPrice(ctx)
@@ -125,12 +133,17 @@ func (k Keeper) MintLiquidityProviderToken(ctx sdk.Context, msg *types.MsgMintLi
 	if err != nil {
 		return err
 	}
+
+	fmt.Println("\nmintAmount\n", mintAmount)
+	fmt.Println("\nmintFee\n", mintFee)
+
 	err = k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.Coins{mintAmount})
 	if err != nil {
 		return err
 	}
 
-	err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, depositor, sdk.Coins{mintAmount.Sub(mintFee)})
+	// tbbt
+	err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, depositor, sdk.Coins{mintAmount.Sub(mintFee)}) //Sub(mintFee)})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
issue: #361 

Beside, i think the first lpt minter should get at least more than `1uglp`.
https://github.com/UnUniFi/chain/blob/2853ea3b802ce9b43e0d8a05dade0b2f76a8bb93/x/derivatives/keeper/lpt.go#L50 

So, not merge this yet. waiting for the response.