### PR TITLE
feat: AMM, Swap fix and test & impl SwapUtToYt

### DIFF
--- a/x/irs/keeper/amm.go
+++ b/x/irs/keeper/amm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/UnUniFi/chain/x/irs/types"
 )
@@ -32,7 +33,10 @@ func (k Keeper) DepositToLiquidityPool(
 
 	// we do an abstract calculation on the lp liquidity coins needed to have
 	// the designated amount of given shares of the pool without performing swap
-	neededLpLiquidity := getMaximalNoSwapLPAmount(ctx, pool, shareOutAmount)
+	neededLpLiquidity, err := GetMaximalNoSwapLPAmount(ctx, pool, shareOutAmount)
+	if err != nil {
+		return nil, sdk.ZeroInt(), err
+	}
 
 	// check that needed lp liquidity does not exceed the given `tokenInMaxs` parameter. Return error if so.
 	// if tokenInMaxs == 0, don't do this check.
@@ -66,11 +70,18 @@ func (k Keeper) DepositToLiquidityPool(
 // 1. calculate how much percent of the pool does given share account for(# of input shares / # of current total shares)
 // 2. since we know how much % of the pool we want, iterate through all pool liquidity to calculate how much coins we need for
 // each pool asset.
-func getMaximalNoSwapLPAmount(ctx sdk.Context, pool types.TranchePool, shareOutAmount sdk.Int) (neededLpLiquidity sdk.Coins) {
+func getMaximalNoSwapLPAmount(ctx sdk.Context, pool types.TranchePool, shareOutAmount sdk.Int) (neededLpLiquidity sdk.Coins, err error) {
 	totalSharesAmount := pool.TotalShares.Amount
+	if totalSharesAmount.IsZero() {
+		return sdk.Coins{}, sdkerrors.Wrapf(types.ErrInvalidMathApprox, "Total shares amount is zero")
+	}
 	// shareRatio is the desired number of shares, divided by the total number of
 	// shares currently in the pool. It is intended to be used in scenarios where you want
 	shareRatio := sdk.NewDecFromInt(shareOutAmount).QuoInt(totalSharesAmount)
+	if shareRatio.LTE(sdk.ZeroDec()) {
+		return sdk.Coins{}, sdkerrors.Wrapf(types.ErrInvalidMathApprox, "Too few shares out wanted. "+
+			"(debug: getMaximalNoSwapLPAmount share ratio is zero or negative)")
+	}
 
 	poolLiquidity := pool.PoolAssets
 	neededLpLiquidity = sdk.Coins{}
@@ -81,7 +92,11 @@ func getMaximalNoSwapLPAmount(ctx sdk.Context, pool types.TranchePool, shareOutA
 		neededCoin := sdk.Coin{Denom: coin.Denom, Amount: neededAmt}
 		neededLpLiquidity = neededLpLiquidity.Add(neededCoin)
 	}
-	return neededLpLiquidity
+	return neededLpLiquidity, nil
+}
+
+func GetMaximalNoSwapLPAmount(ctx sdk.Context, pool types.TranchePool, shareOutAmount sdk.Int) (neededLpLiquidity sdk.Coins, err error) {
+	return getMaximalNoSwapLPAmount(ctx, pool, shareOutAmount)
 }
 
 func (k Keeper) WithdrawFromLiquidityPool(

--- a/x/irs/keeper/amm_test.go
+++ b/x/irs/keeper/amm_test.go
@@ -1,8 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
-
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
@@ -260,8 +258,6 @@ func (suite *KeeperTestSuite) TestGetMaximalNoSwapLPAmount() {
 			neededLpLiquidity, err := keeper.GetMaximalNoSwapLPAmount(ctx, tranchePool, tc.shareOutAmount)
 			if tc.err != nil {
 				suite.Require().Error(err)
-				msgError := fmt.Sprintf("Too few shares out wanted. (debug: getMaximalNoSwapLPAmount share ratio is zero or negative): %s", tc.err)
-				suite.Require().EqualError(err, msgError)
 			} else {
 				suite.Require().NoError(err)
 				suite.Require().Equal(neededLpLiquidity, tc.expectedLpLiquidity)

--- a/x/irs/keeper/swap.go
+++ b/x/irs/keeper/swap.go
@@ -9,7 +9,8 @@ import (
 	"github.com/UnUniFi/chain/x/irs/types"
 )
 
-func (k Keeper) SwapUtToPt(ctx sdk.Context, sender sdk.AccAddress, pool types.TranchePool, tokenIn sdk.Coin) error {
+// SwapPoolTokens swaps tokens in a pool. UT => PT or PT => UT
+func (k Keeper) SwapPoolTokens(ctx sdk.Context, sender sdk.AccAddress, pool types.TranchePool, tokenIn sdk.Coin) error {
 	tokenOutDenom := pool.PoolAssets[0].Denom
 	if tokenOutDenom == tokenIn.Denom {
 		tokenOutDenom = pool.PoolAssets[1].Denom
@@ -18,13 +19,20 @@ func (k Keeper) SwapUtToPt(ctx sdk.Context, sender sdk.AccAddress, pool types.Tr
 	return err
 }
 
-func (k Keeper) SwapPtToUt(ctx sdk.Context, sender sdk.AccAddress, pool types.TranchePool, tokenIn sdk.Coin) error {
+// SimulateSwapPoolTokens simulates a swap in a pool & return TokenOut Amount value. UT => PT or PT => UT
+func (k Keeper) SimulateSwapPoolTokens(ctx sdk.Context, sender sdk.AccAddress, pool types.TranchePool, tokenIn sdk.Coin) (sdk.Coin, error) {
 	tokenOutDenom := pool.PoolAssets[0].Denom
 	if tokenOutDenom == tokenIn.Denom {
 		tokenOutDenom = pool.PoolAssets[1].Denom
 	}
-	_, err := k.SwapExactAmountIn(ctx, sender, pool, tokenIn, tokenOutDenom, sdk.ZeroInt(), pool.SwapFee)
-	return err
+	if tokenIn.Denom == tokenOutDenom {
+		return sdk.Coin{}, errors.New("cannot trade the same denomination in and out")
+	}
+	tokenOutAmount, err := k.CalcSwapExactAmountIn(ctx, sender, pool, tokenIn, tokenOutDenom, sdk.ZeroInt(), pool.SwapFee)
+	if err != nil {
+		return sdk.Coin{}, err
+	}
+	return sdk.NewCoin(tokenOutDenom, tokenOutAmount), nil
 }
 
 func (k Keeper) SwapExactAmountIn(
@@ -48,6 +56,28 @@ func (k Keeper) SwapExactAmountIn(
 		return sdk.Int{}, err
 	}
 
+	tokenOutAmount, err = k.CalcSwapExactAmountIn(ctx, sender, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, swapFee)
+	if err != nil {
+		return sdk.Int{}, err
+	}
+
+	// Settles balances between the tx sender and the pool to match the swap that was executed earlier.
+	// Also emits a swap event and updates related liquidity metrics.
+	k.SetTranchePool(ctx, pool)
+
+	// Subtract swap out fee from the token out amount.
+	return tokenOutAmount, nil
+}
+
+func (k Keeper) CalcSwapExactAmountIn(
+	ctx sdk.Context,
+	sender sdk.AccAddress,
+	pool types.TranchePool,
+	tokenIn sdk.Coin,
+	tokenOutDenom string,
+	tokenOutMinAmount sdk.Int,
+	swapFee sdk.Dec,
+) (tokenOutAmount sdk.Int, err error) {
 	// Executes the swap in the pool and stores the output. Updates pool assets but
 	// does not actually transfer any tokens to or from the pool.
 	tokenOutCoin, err := pool.SwapOutAmtGivenIn(ctx, tokenIn, tokenOutDenom, swapFee)
@@ -65,10 +95,5 @@ func (k Keeper) SwapExactAmountIn(
 		return sdk.Int{}, sdkerrors.Wrapf(types.ErrLimitMinAmount, "%s token is lesser than the minimum amount", tokenOutDenom)
 	}
 
-	// Settles balances between the tx sender and the pool to match the swap that was executed earlier.
-	// Also emits a swap event and updates related liquidity metrics.
-	k.SetTranchePool(ctx, pool)
-
-	// Subtract swap out fee from the token out amount.
 	return tokenOutAmount, nil
 }

--- a/x/irs/keeper/swap.go
+++ b/x/irs/keeper/swap.go
@@ -28,7 +28,7 @@ func (k Keeper) SimulateSwapPoolTokens(ctx sdk.Context, pool types.TranchePool, 
 	if tokenIn.Denom == tokenOutDenom {
 		return sdk.Coin{}, errors.New("cannot trade the same denomination in and out")
 	}
-	tokenOutAmount, err := k.CalcSwapExactAmountIn(ctx, pool, tokenIn, tokenOutDenom, sdk.ZeroInt(), pool.SwapFee)
+	tokenOutAmount, err := k.CalculateSwapExactAmountIn(ctx, pool, tokenIn, tokenOutDenom, sdk.ZeroInt(), pool.SwapFee)
 	if err != nil {
 		return sdk.Coin{}, err
 	}
@@ -56,7 +56,7 @@ func (k Keeper) SwapExactAmountIn(
 		return sdk.Int{}, err
 	}
 
-	tokenOutAmount, err = k.CalcSwapExactAmountIn(ctx, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, swapFee)
+	tokenOutAmount, err = k.CalculateSwapExactAmountIn(ctx, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, swapFee)
 	if err != nil {
 		return sdk.Int{}, err
 	}
@@ -69,7 +69,7 @@ func (k Keeper) SwapExactAmountIn(
 	return tokenOutAmount, nil
 }
 
-func (k Keeper) CalcSwapExactAmountIn(
+func (k Keeper) CalculateSwapExactAmountIn(
 	ctx sdk.Context,
 	pool types.TranchePool,
 	tokenIn sdk.Coin,

--- a/x/irs/keeper/swap.go
+++ b/x/irs/keeper/swap.go
@@ -20,7 +20,7 @@ func (k Keeper) SwapPoolTokens(ctx sdk.Context, sender sdk.AccAddress, pool type
 }
 
 // SimulateSwapPoolTokens simulates a swap in a pool & return TokenOut Amount value. UT => PT or PT => UT
-func (k Keeper) SimulateSwapPoolTokens(ctx sdk.Context, sender sdk.AccAddress, pool types.TranchePool, tokenIn sdk.Coin) (sdk.Coin, error) {
+func (k Keeper) SimulateSwapPoolTokens(ctx sdk.Context, pool types.TranchePool, tokenIn sdk.Coin) (sdk.Coin, error) {
 	tokenOutDenom := pool.PoolAssets[0].Denom
 	if tokenOutDenom == tokenIn.Denom {
 		tokenOutDenom = pool.PoolAssets[1].Denom
@@ -28,7 +28,7 @@ func (k Keeper) SimulateSwapPoolTokens(ctx sdk.Context, sender sdk.AccAddress, p
 	if tokenIn.Denom == tokenOutDenom {
 		return sdk.Coin{}, errors.New("cannot trade the same denomination in and out")
 	}
-	tokenOutAmount, err := k.CalcSwapExactAmountIn(ctx, sender, pool, tokenIn, tokenOutDenom, sdk.ZeroInt(), pool.SwapFee)
+	tokenOutAmount, err := k.CalcSwapExactAmountIn(ctx, pool, tokenIn, tokenOutDenom, sdk.ZeroInt(), pool.SwapFee)
 	if err != nil {
 		return sdk.Coin{}, err
 	}
@@ -56,7 +56,7 @@ func (k Keeper) SwapExactAmountIn(
 		return sdk.Int{}, err
 	}
 
-	tokenOutAmount, err = k.CalcSwapExactAmountIn(ctx, sender, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, swapFee)
+	tokenOutAmount, err = k.CalcSwapExactAmountIn(ctx, pool, tokenIn, tokenOutDenom, tokenOutMinAmount, swapFee)
 	if err != nil {
 		return sdk.Int{}, err
 	}
@@ -71,7 +71,6 @@ func (k Keeper) SwapExactAmountIn(
 
 func (k Keeper) CalcSwapExactAmountIn(
 	ctx sdk.Context,
-	sender sdk.AccAddress,
 	pool types.TranchePool,
 	tokenIn sdk.Coin,
 	tokenOutDenom string,

--- a/x/irs/keeper/swap_advanced_test.go
+++ b/x/irs/keeper/swap_advanced_test.go
@@ -1,0 +1,5 @@
+package keeper_test
+
+import (
+// sdk "github.com/cosmos/cosmos-sdk/types"
+)

--- a/x/irs/keeper/swap_test.go
+++ b/x/irs/keeper/swap_test.go
@@ -8,16 +8,6 @@ import (
 	"github.com/UnUniFi/chain/x/irs/types"
 )
 
-// SwapUtToPt(ctx sdk.Context, sender sdk.AccAddress, pool types.TranchePool, tokenIn sdk.Coin) error {
-// SwapPtToUt(ctx sdk.Context, sender sdk.AccAddress, pool types.TranchePool, tokenIn sdk.Coin) error {
-// UpdatePoolForSwap(
-// 	ctx sdk.Context,
-// 	pool types.TranchePool,
-// 	sender sdk.AccAddress,
-// 	tokenIn sdk.Coin,
-// 	tokenOut sdk.Coin,
-// ) error
-
 func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 	sender := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address().Bytes())
 

--- a/x/irs/keeper/swap_test.go
+++ b/x/irs/keeper/swap_test.go
@@ -44,44 +44,46 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 		{
 			name: "Proper swap",
 			param: param{
-				tokenIn:           sdk.NewCoin(pt, sdk.NewInt(100000)),
+				tokenIn:           sdk.NewCoin(pt, sdk.NewInt(100_000)),
 				tokenOutDenom:     ut,
 				tokenOutMinAmount: sdk.NewInt(1),
-				expectedTokenOut:  sdk.NewInt(49262),
+				expectedTokenOut:  sdk.NewInt(4992),
 			},
+			swapFee:    sdk.ZeroDec(),
 			expectPass: true,
 		},
 		{
 			name: "Proper swap2",
 			param: param{
-				tokenIn:           sdk.NewCoin(ut, sdk.NewInt(2451783)),
+				tokenIn:           sdk.NewCoin(ut, sdk.NewInt(2_000)),
 				tokenOutDenom:     pt,
 				tokenOutMinAmount: sdk.NewInt(1),
-				expectedTokenOut:  sdk.NewInt(1167843),
+				expectedTokenOut:  sdk.NewInt(1499),
 			},
+			swapFee:    sdk.ZeroDec(),
 			expectPass: true,
 		},
 		{
-			name: "boundary valid spread factor given (= 0.5 pool spread factor)",
+			name: "too much token in",
 			param: param{
-				tokenIn:           sdk.NewCoin(pt, sdk.NewInt(100000)),
-				tokenOutDenom:     ut,
+				tokenIn:           sdk.NewCoin(ut, sdk.NewInt(999_999)),
+				tokenOutDenom:     pt,
 				tokenOutMinAmount: sdk.NewInt(1),
-				expectedTokenOut:  sdk.NewInt(46833),
+				expectedTokenOut:  sdk.NewInt(1),
 			},
-			swapFee:    sdk.MustNewDecFromStr("0.1"),
-			expectPass: true,
-		},
-		{
-			name: "invalid spread factor given (< 0.5 pool spread factor)",
-			param: param{
-				tokenIn:           sdk.NewCoin(pt, sdk.NewInt(100000)),
-				tokenOutDenom:     ut,
-				tokenOutMinAmount: sdk.NewInt(1),
-				expectedTokenOut:  sdk.NewInt(49262),
-			},
-			swapFee:    sdk.MustNewDecFromStr("0.1"),
+			swapFee:    sdk.ZeroDec(),
 			expectPass: false,
+		},
+		{
+			name: "Proper swap with swap fee",
+			param: param{
+				tokenIn:           sdk.NewCoin(pt, sdk.NewInt(100_000)),
+				tokenOutDenom:     ut,
+				tokenOutMinAmount: sdk.NewInt(1),
+				expectedTokenOut:  sdk.NewInt(4987),
+			},
+			swapFee:    sdk.MustNewDecFromStr("0.1"),
+			expectPass: true,
 		},
 		{
 			name: "out is lesser than min amount",
@@ -90,15 +92,17 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 				tokenOutDenom:     ut,
 				tokenOutMinAmount: sdk.NewInt(9000000),
 			},
+			swapFee:    sdk.ZeroDec(),
 			expectPass: false,
 		},
 		{
 			name: "in and out denom are same",
 			param: param{
-				tokenIn:           sdk.NewCoin(pt, sdk.NewInt(2451783)),
+				tokenIn:           sdk.NewCoin(ut, sdk.NewInt(100_000)),
 				tokenOutDenom:     ut,
 				tokenOutMinAmount: sdk.NewInt(1),
 			},
+			swapFee:    sdk.ZeroDec(),
 			expectPass: false,
 		},
 		{
@@ -108,6 +112,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 				tokenOutDenom:     ut,
 				tokenOutMinAmount: sdk.NewInt(1),
 			},
+			swapFee:    sdk.ZeroDec(),
 			expectPass: false,
 		},
 		{
@@ -117,6 +122,7 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 				tokenOutDenom:     "unknown",
 				tokenOutMinAmount: sdk.NewInt(1),
 			},
+			swapFee:    sdk.ZeroDec(),
 			expectPass: false,
 		},
 	}
@@ -138,9 +144,9 @@ func (s *KeeperTestSuite) TestSwapExactAmountIn() {
 			tranchePool := types.TranchePool{
 				Id:               1,
 				StrategyContract: strategyContract.String(),
-				StartTime:        uint64(ctx.BlockTime().Unix()),
-				Maturity:         86400 * 180,
-				SwapFee:          sdk.NewDecWithPrec(3, 3), // 0.3%
+				StartTime:        uint64(ctx.BlockTime().Unix() - 86400*30), // 30 days ago
+				Maturity:         86400 * 180,                               // 180 days maturity
+				SwapFee:          sdk.NewDecWithPrec(3, 3),                  // 0.3%
 				ExitFee:          sdk.ZeroDec(),
 				TotalShares:      sdk.NewCoin(lp, existingShares),
 				PoolAssets:       poolTokens,

--- a/x/irs/keeper/tranche.go
+++ b/x/irs/keeper/tranche.go
@@ -98,7 +98,7 @@ func (k Keeper) DepositToTranchePool(ctx sdk.Context, sender sdk.AccAddress, tra
 		}
 	} else if trancheType == types.TrancheType_FIXED_YIELD {
 		// Buy PT from AMM with msg.TrancheMaturity for msg.SpendAmount
-		err := k.SwapUtToPt(ctx, sender, tranche, token)
+		err := k.SwapPoolTokens(ctx, sender, tranche, token)
 		if err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ func (k Keeper) WithdrawFromTranchePool(ctx sdk.Context, sender sdk.AccAddress, 
 			}
 		} else {
 			// Else, sell PT from AMM with msg.TrancheMaturity for msg.PTAmount
-			err := k.SwapPtToUt(ctx, sender, tranche, tokens[0])
+			err := k.SwapPoolTokens(ctx, sender, tranche, tokens[0])
 			if err != nil {
 				return err
 			}

--- a/x/irs/keeper/tranche.go
+++ b/x/irs/keeper/tranche.go
@@ -107,7 +107,10 @@ func (k Keeper) DepositToTranchePool(ctx sdk.Context, sender sdk.AccAddress, tra
 		// MintPtYtPair
 		// Sell msg.AmountToBuy worth of PT
 		// Return borrowed amount
-		k.SwapUtToYt(ctx, sender, tranche, requiredYt)
+		err := k.SwapUtToYt(ctx, sender, tranche, requiredYt, token)
+		if err != nil {
+			return err
+		}
 	} else {
 		return types.ErrInvalidTrancheType
 	}

--- a/x/irs/types/errors.go
+++ b/x/irs/types/errors.go
@@ -24,4 +24,6 @@ var (
 	ErrSupplyNotFound          = errors.Register(ModuleName, 16, "supply not found")
 	ErrInvalidTrancheType      = errors.Register(ModuleName, 17, "invalid tranche type")
 	ErrInvalidTrancheStartTime = errors.Register(ModuleName, 18, "invalid tranche start time")
+	ErrInsufficientFunds       = errors.Register(ModuleName, 19, "insufficient funds")
+	ErrInvalidDepositDenom     = errors.Register(ModuleName, 20, "invalid deposit denom")
 )

--- a/x/irs/types/errors.go
+++ b/x/irs/types/errors.go
@@ -23,4 +23,5 @@ var (
 	ErrZeroAmount              = errors.Register(ModuleName, 15, "zero amount")
 	ErrSupplyNotFound          = errors.Register(ModuleName, 16, "supply not found")
 	ErrInvalidTrancheType      = errors.Register(ModuleName, 17, "invalid tranche type")
+	ErrInvalidTrancheStartTime = errors.Register(ModuleName, 18, "invalid tranche start time")
 )

--- a/x/irs/types/pool.go
+++ b/x/irs/types/pool.go
@@ -251,6 +251,9 @@ func (p TranchePool) CalcOutAmtGivenIn(
 	if !t.IsPositive() {
 		return sdk.Coin{}, sdkerrors.Wrapf(ErrTrancheAlreadyMatured, "tranche has been already matured")
 	}
+	if t.GTE(sdk.OneDec()) {
+		return sdk.Coin{}, ErrInvalidTrancheStartTime
+	}
 	tokenAmountOut := solveConstantFunctionInvariant(
 		t,
 		poolTokenInBalance,
@@ -293,6 +296,11 @@ func solveConstantFunctionInvariant(
 	// y2^(1-t) = k - x2^(1-t)
 	y2exp := k.Sub(osmomath.BigDecFromSDKDec(tokenBalanceFixedAfter).Power(exp))
 	// y2 = y2^(1-t)^(1/(1-t))
+	if y2exp.IsNegative() {
+		// TODO: return y1 or error
+		// Plz verify that y can be 0 in other codes.
+		return sdk.ZeroDec()
+	}
 	y2 := y2exp.Power(osmomath.BigDecFromSDKDec(sdk.OneDec()).Quo(exp))
 	// TokenOut to be issued = y1 - y2
 	return y1.Sub(y2).SDKDec()

--- a/x/irs/types/pool.go
+++ b/x/irs/types/pool.go
@@ -219,7 +219,7 @@ func (p *TranchePool) SwapOutAmtGivenIn(
 		return sdk.Coin{}, err
 	}
 
-	err = p.applySwap(ctx, tokenIn, balancerOutCoin, sdk.ZeroDec(), swapFee)
+	err = p.applySwap(tokenIn, balancerOutCoin, sdk.ZeroDec(), swapFee)
 	if err != nil {
 		return sdk.Coin{}, err
 	}
@@ -270,7 +270,7 @@ func (p TranchePool) CalcOutAmtGivenIn(
 	return sdk.NewCoin(tokenOutDenom, tokenAmountOutInt), nil
 }
 
-func (p *TranchePool) applySwap(ctx sdk.Context, tokenIn sdk.Coin, tokenOut sdk.Coin, swapFeeIn, swapFeeOut sdk.Dec) error {
+func (p *TranchePool) applySwap(tokenIn sdk.Coin, tokenOut sdk.Coin, swapFeeIn, swapFeeOut sdk.Dec) error {
 	inTokensAfterFee := sdk.NewDecFromInt(tokenIn.Amount).Mul(sdk.OneDec().Sub(swapFeeIn)).TruncateInt()
 	outTokensAfterFee := sdk.NewDecFromInt(tokenOut.Amount).Mul(sdk.OneDec().Sub(swapFeeOut)).TruncateInt()
 

--- a/x/irs/types/pool_test.go
+++ b/x/irs/types/pool_test.go
@@ -547,9 +547,8 @@ func TestApplySwap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := sdk.Context{}
 			pool := poolStructFromAssets(test.currentPoolAssets)
-			err := pool.applySwap(ctx, test.tokenIn, test.tokenOut, test.swapFeeIn, test.swapFeeOut)
+			err := pool.applySwap(test.tokenIn, test.tokenOut, test.swapFeeIn, test.swapFeeOut)
 			if test.expectPass {
 				require.NoError(t, err)
 				require.Equal(t, test.newPoolAssets, sdk.Coins(pool.PoolAssets))


### PR DESCRIPTION
Change AMM code & Impl test
- Added error when StartTime is less than block time
- Added error handling for AMM functions
`k = x1^(1-t) + y1^(1-t)`
If x2 is too large `x2^(1-t) > k`, so `y2^(1-t)` become < 0.
Then `y2 = y2^(1-t)^(1/(1-t))` cannot be calculated.

Therefore, return value should be 0 or y1(all amount in pool).
Current returns 0 (= error), but you may verify that you can give y1 and set y in the pool to 0.

I think error return is a safe now.