### PR TITLE
fix: pt amount calc 

### DIFF
--- a/x/irs/keeper/grpc_query_estimate_mint_pt_yt_pair.go
+++ b/x/irs/keeper/grpc_query_estimate_mint_pt_yt_pair.go
@@ -27,15 +27,17 @@ func (k Keeper) EstimateMintPtYtPair(c context.Context, req *types.QueryEstimate
 	if !ok {
 		return nil, types.ErrInvalidAmount
 	}
-	mintAmount, err := k.CalculateMintPtAmount(ctx, tranche, sdk.NewCoin(req.Denom, depositAmount))
-	if err != nil {
-		return nil, err
-	}
+
+	// old impl
+	// mintAmount, err := k.CalculateMintPtAmount(ctx, tranche, sdk.NewCoin(req.Denom, depositAmount))
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	ptDenom := types.PtDenom(tranche)
 	ytDenom := types.YtDenom(tranche)
 	return &types.QueryEstimateMintPtYtPairResponse{
-		PtAmount: sdk.NewCoin(ptDenom, mintAmount),
+		PtAmount: sdk.NewCoin(ptDenom, depositAmount),
 		YtAmount: sdk.NewCoin(ytDenom, depositAmount),
 	}, nil
 }

--- a/x/irs/keeper/grpc_query_tranche_apys.go
+++ b/x/irs/keeper/grpc_query_tranche_apys.go
@@ -52,10 +52,7 @@ func (k Keeper) TrancheYtAPYs(c context.Context, req *types.QueryTrancheYtAPYsRe
 		return nil, err
 	}
 	if requiredDeposit.IsZero() {
-		return &types.QueryTrancheYtAPYsResponse{
-			YtApy:            sdk.ZeroDec(),
-			YtRatePerDeposit: sdk.ZeroDec(),
-		}, nil
+		return nil, types.ErrNoDepositRequired
 	}
 
 	// YT APY = stATOM APY * SwapRate (stATOM => YT) - 1

--- a/x/irs/keeper/stripping.go
+++ b/x/irs/keeper/stripping.go
@@ -321,6 +321,8 @@ func (k Keeper) CalculateRedeemYtAmount(ctx sdk.Context, pool types.TranchePool,
 		return sdk.ZeroInt(), err
 	}
 
+	// vault amount: UT (NOT deposit_denom) present in strategy
+	// Redeemed UT Amount = (amount in vault - PT supply) * (redeem YT / YT supply)
 	utAmount := vaultAmount.Sub(ptSupply.Amount).Mul(ytAmount.Amount).Quo(ytSupply.Amount)
 	info := k.GetStrategyDepositInfo(ctx, pool.StrategyContract)
 	rate := sdk.MustNewDecFromStr(info.DepositDenomRate)

--- a/x/irs/keeper/swap_advanced.go
+++ b/x/irs/keeper/swap_advanced.go
@@ -65,13 +65,15 @@ func (k Keeper) CalculateRequiredDepositSwapToYt(ctx sdk.Context, pool types.Tra
 	loanAmount := sdk.NewDecFromInt(requiredYtAmount).Mul(rate).TruncateInt()
 	loan := sdk.NewCoin(pool.DepositDenom, loanAmount)
 	ptDenom := types.PtDenom(pool)
-	// estimation 2. PT amount to mint
-	estimatedPtAmount, err := k.CalculateMintPtAmount(ctx, pool, loan)
-	if err != nil {
-		return sdk.Coin{}, err
-	}
+
+	// deprecated: estimation 2. PT amount to mint
+	// estimatedPtAmount, err := k.CalculateMintPtAmount(ctx, pool, loan)
+	// if err != nil {
+	// 	return sdk.Coin{}, err
+	// }
+
 	// estimation 3. token amount to get by selling PT
-	estimatedSwap, err := k.SimulateSwapPoolTokens(ctx, pool, sdk.NewCoin(ptDenom, estimatedPtAmount))
+	estimatedSwap, err := k.SimulateSwapPoolTokens(ctx, pool, sdk.NewCoin(ptDenom, loanAmount))
 	if err != nil {
 		return sdk.Coin{}, err
 	}

--- a/x/irs/types/errors.go
+++ b/x/irs/types/errors.go
@@ -33,4 +33,5 @@ var (
 	ErrInvalidPoolAssets       = errors.Register(ModuleName, 26, "invalid pool assets")
 	ErrZeroDepositRate         = errors.Register(ModuleName, 27, "zero deposit rate")
 	ErrNoDepositDenomExists    = errors.Register(ModuleName, 28, "no deposit denom exists")
+	ErrNoDepositRequired       = errors.Register(ModuleName, 28, "no deposit required")
 )


### PR DESCRIPTION
Change PT amount when minted

- old
`PT mint amount = deposit * (1-(strategyAmount)/YT Supply)`

- new
`PT mint amount = deposit / deposit denom rate`

This makes theAPY when minted match the APY on the Strategy.

ex. 
10 stATOM => 10 PT + 10YT

10 PT can be redeemed to `10 * deposit denom rate` stATOM after maturity.

10 YT can be redeemed to `(vault amount - PT supply) * (YT redeem amount / YT supply)` after maturity



